### PR TITLE
Update trimQuotesAndSpace

### DIFF
--- a/auparse/auparse.go
+++ b/auparse/auparse.go
@@ -311,7 +311,16 @@ func extractKeyValuePairs(msg string, data map[string]*field) {
 	}
 }
 
-func trimQuotesAndSpace(v string) string { return strings.Trim(v, `'" `) }
+func trimQuotesAndSpace(v string) string {
+	quoteChars := []string{"'", `"`}
+	for _, c := range quoteChars {
+		if strings.HasPrefix(v, c) && strings.HasSuffix(v, c) {
+			v = v[len(c) : len(v)-len(c)]
+			break
+		}
+	}
+	return strings.TrimSpace(v)
+}
 
 // Enrichment after KV parsing
 

--- a/auparse/auparse_test.go
+++ b/auparse/auparse_test.go
@@ -363,3 +363,32 @@ func ExampleParseLogLine() {
 	//   "uid": "0"
 	//}
 }
+
+func Test_trimQuotesAndSpace(t *testing.T) {
+	tests := []struct {
+		v    string
+		want string
+	}{
+		{"", ""},
+		{`'value'`, "value"},
+		{`'value  '`, "value"},
+		{`'  value'`, "value"},
+		{`'  value '`, "value"},
+
+		{`"value"`, "value"},
+		{`"value  "`, "value"},
+		{`"  value"`, "value"},
+		{`"  value "`, "value"},
+
+		{` "value"`, `"value"`},
+		{`'value"`, `'value"`},
+		{`'"value"'`, `"value"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.v, func(t *testing.T) {
+			if got := trimQuotesAndSpace(tt.v); got != tt.want {
+				t.Errorf("trimQuotesAndSpace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hopefully more correct: remove only one set of matching quote chars at
the beginning and the end of the string.