### PR TITLE
implement binary heap to avoid sorting array of event ids on each new…

### DIFF
--- a/reassembler.go
+++ b/reassembler.go
@@ -143,19 +143,19 @@ func (r *Reassembler) callback(events []*event, lost int) {
 
 const maxSortRange = 1<<24 - 1
 
-type heapInt []int
+type intHeap []int
 
-func (h heapInt) Len() int { return len(h) }
-func (h heapInt) Less(i, j int) bool {
+func (h intHeap) Len() int { return len(h) }
+func (h intHeap) Less(i, j int) bool {
 	if math.Abs(float64(h[i]-h[j])) > maxSortRange {
 		return h[i] > h[j]
 	}
 	return h[i] < h[j]
 }
-func (h heapInt) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
-func (h *heapInt) Push(x interface{}) { *h = append(*h, x.(int)) }
+func (h intHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *intHeap) Push(x interface{}) { *h = append(*h, x.(int)) }
 
-func (h *heapInt) Pop() interface{} {
+func (h *intHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]
@@ -190,7 +190,7 @@ func (e *event) IsExpired() bool {
 
 type eventList struct {
 	sync.Mutex
-	seqs    *heapInt
+	seqs    *intHeap
 	events  map[int]*event
 	lastSeq int
 	maxSize int
@@ -198,7 +198,7 @@ type eventList struct {
 }
 
 func newEventList(maxSize int, timeout time.Duration) *eventList {
-	h := &heapInt{}
+	h := &intHeap{}
 	heap.Init(h)
 	return &eventList{
 		seqs:    h,

--- a/reassembler.go
+++ b/reassembler.go
@@ -18,7 +18,6 @@
 package libaudit
 
 import (
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -98,8 +97,8 @@ func (r *Reassembler) PushMessage(msg *auparse.AuditMessage) {
 // function that handles calling auparse.Parse() to extract the message's
 // timestamp and sequence number. If parsing fails then an error will be
 // returned. See PushMessage.
-func (r *Reassembler) Push(typ auparse.AuditMessageType, rawData []byte) error {
-	msg, err := auparse.Parse(auparse.AuditMessageType(typ), string(rawData))
+func (r *Reassembler) Push(msgType auparse.AuditMessageType, rawData []byte) error {
+	msg, err := auparse.Parse(msgType, string(rawData))
 	if err != nil {
 		return err
 	}
@@ -140,35 +139,25 @@ func (r *Reassembler) callback(events []*event, lost int) {
 	}
 }
 
-type sequenceNum uint32
+type heap []int
 
-// Type - sequenceNumSlice
+func (h heap) Len() int            { return len(h) }
+func (h heap) Less(i, j int) bool  { return h[i] < h[j] }
+func (h heap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *heap) Push(x interface{}) { *h = append(*h, x.(int)) }
 
-// maxSortRange defines the maximum range that sequence number can differ
-// before being considered to have rolled over. When two values differ by more
-// than this constant, the larger values is treated as being less.
-const maxSortRange = 1<<24 - 1
-
-type sequenceNumSlice []sequenceNum
-
-func (p sequenceNumSlice) Len() int      { return len(p) }
-func (p sequenceNumSlice) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
-func (p sequenceNumSlice) Sort()         { sort.Sort(p) }
-
-func (p sequenceNumSlice) Less(i, j int) bool {
-	// Handle sequence number rollover.
-	diff := abs(int64(p[i]) - int64(p[j]))
-	if diff > maxSortRange {
-		return p[i] > p[j]
-	}
-
-	return p[i] < p[j]
+func (h *heap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
 }
 
-func abs(x int64) int64 {
-	if x < 0 {
-		return -x
-	}
+func (h *heap) Shift() int {
+	old := *h
+	x := old[0]
+	*h = old[1:]
 	return x
 }
 
@@ -199,17 +188,17 @@ func (e *event) IsExpired() bool {
 
 type eventList struct {
 	sync.Mutex
-	seqs    sequenceNumSlice
-	events  map[sequenceNum]*event
-	lastSeq sequenceNum
+	seqs    *heap
+	events  map[int]*event
+	lastSeq int
 	maxSize int
 	timeout time.Duration
 }
 
 func newEventList(maxSize int, timeout time.Duration) *eventList {
 	return &eventList{
-		seqs:    make([]sequenceNum, 0, maxSize+1),
-		events:  make(map[sequenceNum]*event, maxSize+1),
+		seqs:    &heap{},
+		events:  make(map[int]*event, maxSize+1),
 		maxSize: maxSize,
 		timeout: timeout,
 	}
@@ -217,9 +206,8 @@ func newEventList(maxSize int, timeout time.Duration) *eventList {
 
 // remove the first event (lowest sequence) in the list.
 func (l *eventList) remove() {
-	if len(l.seqs) > 0 {
-		seq := l.seqs[0]
-		l.seqs = l.seqs[1:]
+	if l.seqs.Len() > 0 {
+		seq := l.seqs.Shift()
 		delete(l.events, seq)
 	}
 }
@@ -231,20 +219,18 @@ func (l *eventList) Clear() ([]*event, int) {
 	defer l.Unlock()
 
 	var lost int
-	var seq sequenceNum
 	var evicted []*event
 	for {
-		size := len(l.seqs)
-		if size == 0 {
+		if l.seqs.Len() == 0 {
 			break
 		}
 
 		// Get event.
-		seq = l.seqs[0]
+		seq := (*l.seqs)[0]
 		event := l.events[seq]
 
 		if l.lastSeq > 0 {
-			lost += int(seq - l.lastSeq - 1)
+			lost += seq - l.lastSeq - 1
 		}
 		l.lastSeq = seq
 		evicted = append(evicted, event)
@@ -259,7 +245,7 @@ func (l *eventList) Put(msg *auparse.AuditMessage) {
 	l.Lock()
 	defer l.Unlock()
 
-	seq := sequenceNum(msg.Sequence)
+	seq := int(msg.Sequence)
 	e, found := l.events[seq]
 
 	// Mark as complete, but do not append.
@@ -271,8 +257,7 @@ func (l *eventList) Put(msg *auparse.AuditMessage) {
 	}
 
 	if !found {
-		l.seqs = append(l.seqs, seq)
-		l.seqs.Sort()
+		l.seqs.Push(seq)
 
 		e = &event{
 			expireTime: time.Now().Add(l.timeout),
@@ -289,21 +274,20 @@ func (l *eventList) CleanUp() ([]*event, int) {
 	defer l.Unlock()
 
 	var lost int
-	var seq sequenceNum
 	var evicted []*event
 	for {
-		size := len(l.seqs)
+		size := l.seqs.Len()
 		if size == 0 {
 			break
 		}
 
 		// Get event.
-		seq = l.seqs[0]
+		seq := (*l.seqs)[0]
 		event := l.events[seq]
 
 		if event.complete || size > l.maxSize || event.IsExpired() {
 			if l.lastSeq > 0 {
-				lost += int(seq - l.lastSeq - 1)
+				lost += seq - l.lastSeq - 1
 			}
 			l.lastSeq = seq
 			evicted = append(evicted, event)

--- a/reassembler_test.go
+++ b/reassembler_test.go
@@ -185,7 +185,7 @@ func generateEvents() *eventList {
 		maxSize: maxSize,
 	}
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		var msgType auparse.AuditMessageType
 		if i%2 == 0 {
 			msgType = auparse.AUDIT_EOE
@@ -200,11 +200,12 @@ func generateEvents() *eventList {
 }
 
 func Benchmark_eventList_cleanup(b *testing.B) {
-	eventList := generateEvents()
-
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		eventList := generateEvents()
+		b.StartTimer()
 		eventList.CleanUp()
 	}
 }

--- a/reassembler_test.go
+++ b/reassembler_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/elastic/go-libaudit/v2/auparse"
 )
 
-const maxSeq sequenceNum = 1<<32 - 1
-
 type testStream struct {
 	events  [][]*auparse.AuditMessage
 	dropped int
@@ -148,12 +146,4 @@ func testReassembler(t testing.TB, file string, expected *results) {
 		}
 		assert.Equal(t, expectedEvent.count, len(stream.events[i]), "message count")
 	}
-}
-
-func TestSequenceNumSliceSort(t *testing.T) {
-	expected := sequenceNumSlice{maxSeq - 5, maxSeq - 4, maxSeq - 3, maxSeq - 2, maxSeq, 0, 1, 2, 3, 4}
-	seqs := sequenceNumSlice{maxSeq - 5, maxSeq - 4, 0, 1, 2, maxSeq - 3, maxSeq - 2, maxSeq, 3, 4}
-	seqs.Sort()
-
-	assert.Equal(t, expected, seqs)
 }

--- a/reassembler_test.go
+++ b/reassembler_test.go
@@ -156,10 +156,9 @@ func Benchmark_eventList(b *testing.B) {
 		maxSize: maxSize,
 	}
 
-	b.ReportAllocs()
-
 	b.ResetTimer()
 	b.Run("put", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			var msgType auparse.AuditMessageType
 			if i%2 == 0 {
@@ -174,6 +173,7 @@ func Benchmark_eventList(b *testing.B) {
 
 	b.ResetTimer()
 	b.Run("cleanup", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			eventList.CleanUp()
 		}

--- a/reassembler_test.go
+++ b/reassembler_test.go
@@ -152,7 +152,7 @@ func testReassembler(t testing.TB, file string, expected *results) {
 
 func Benchmark_eventList_put(b *testing.B) {
 	const maxSize = 10
-	h := &heapInt{}
+	h := &intHeap{}
 	heap.Init(h)
 	eventList := &eventList{
 		seqs:    h,
@@ -177,7 +177,7 @@ func Benchmark_eventList_put(b *testing.B) {
 
 func generateEvents() *eventList {
 	const maxSize = 10
-	h := &heapInt{}
+	h := &intHeap{}
 	heap.Init(h)
 	eventList := &eventList{
 		seqs:    h,


### PR DESCRIPTION
using heap instead of an array, since it allows to insert in O(log n) and find a minimum in O(1) (instead of O(n log n) for insert and O(1) for finding a minimum), where n - count of the simultaneously built audit event