### PR TITLE
Parse log lines starting with "node=... type="

### DIFF
--- a/auparse/auparse.go
+++ b/auparse/auparse.go
@@ -161,13 +161,19 @@ func ParseLogLine(line string) (*AuditMessage, error) {
 		return nil, errInvalidAuditHeader
 	}
 
+	typeIndex := strings.Index(line, typeToken)
+	if typeIndex == -1 {
+		return nil, errInvalidAuditHeader
+	}
+	typeTokenLen := len(typeToken) + typeIndex
+
 	// Verify type=XXX is before msg=
-	if msgIndex < len(typeToken)+1 {
+	if msgIndex < typeTokenLen+1 {
 		return nil, errInvalidAuditHeader
 	}
 
 	// Convert the type to a number (i.e. type=SYSCALL -> 1300).
-	typName := line[len(typeToken) : msgIndex-1]
+	typName := line[typeTokenLen : msgIndex-1]
 	typ, err := GetAuditMessageType(typName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
ParseLogLine fails to parse lines such as "node=... type=PATH msg=..." with error: 'invalid message type'

 Account for the character count preceding the 'type=' key.


